### PR TITLE
added ability to use webmethod to mark an endpoint as deprecated

### DIFF
--- a/pyopenapi/decorators.py
+++ b/pyopenapi/decorators.py
@@ -18,6 +18,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 def webmethod(
     route: Optional[str] = None,
     public: Optional[bool] = False,
+    deprecated: Optional[bool] = False,
     request_example: Optional[Any] = None,
     response_example: Optional[Any] = None,
     request_examples: Optional[list[Any]] = None,
@@ -45,7 +46,7 @@ def webmethod(
         response_examples = [response_example]
 
     def wrap(cls: F) -> F:
-        cls.__webmethod__ = WebMethod(route=route, public=public or False, request_examples=request_examples, response_examples=response_examples)  # type: ignore[attr-defined]
+        cls.__webmethod__ = WebMethod(route=route, public=public or False, deprecated=deprecated or False, request_examples=request_examples, response_examples=response_examples)  # type: ignore[attr-defined]
         return cls
 
     return wrap

--- a/pyopenapi/generator.py
+++ b/pyopenapi/generator.py
@@ -534,6 +534,7 @@ class Generator:
             responses=responses,
             callbacks=callbacks,
             security=[] if op.public else None,
+            deprecated = op.deprecated
         )
 
     def generate(self) -> Document:

--- a/pyopenapi/metadata.py
+++ b/pyopenapi/metadata.py
@@ -23,5 +23,6 @@ class WebMethod:
 
     route: Optional[str] = None
     public: bool = False
+    deprecated: bool = False
     request_examples: Optional[list[Any]] = None
     response_examples: Optional[list[Any]] = None

--- a/pyopenapi/operations.py
+++ b/pyopenapi/operations.py
@@ -86,6 +86,7 @@ class EndpointOperation:
     :param response_type: The Python type of the data that is transmitted in the response body.
     :param http_method: The HTTP method used to invoke the endpoint such as POST, GET or PUT.
     :param public: True if the operation can be invoked without prior authentication.
+    :param deprecated: True if operation is deprecated
     :param request_examples: Sample requests that the operation might take.
     :param response_examples: Sample responses that the operation might produce.
     """
@@ -102,6 +103,7 @@ class EndpointOperation:
     response_type: type
     http_method: HTTPMethod
     public: bool
+    deprecated: bool
     request_examples: Optional[list[Any]] = None
     response_examples: Optional[list[Any]] = None
 
@@ -201,12 +203,14 @@ def get_endpoint_operations(endpoint: type, use_examples: bool = True) -> list[E
             route = webmethod.route
             route_params = _get_route_parameters(route) if route is not None else None
             public = webmethod.public
+            deprecated = webmethod.deprecated
             request_examples = webmethod.request_examples
             response_examples = webmethod.response_examples
         else:
             route = None
             route_params = None
             public = False
+            deprecated = False
             request_examples = None
             response_examples = None
 
@@ -308,6 +312,7 @@ def get_endpoint_operations(endpoint: type, use_examples: bool = True) -> list[E
                 response_type=response_type,
                 http_method=http_method,
                 public=public,
+                deprecated=deprecated,
                 request_examples=request_examples if use_examples else None,
                 response_examples=response_examples if use_examples else None,
             )

--- a/pyopenapi/specification.py
+++ b/pyopenapi/specification.py
@@ -121,6 +121,7 @@ class Operation:
     requestBody: Optional[RequestBody] = None
     callbacks: Optional[dict[str, "Callback"]] = None
     security: Optional[list["SecurityRequirement"]] = None
+    deprecated: Optional[bool] = None
 
 
 @dataclass


### PR DESCRIPTION
follows same pattern as the 'public' field